### PR TITLE
Harden template type annotations in DOMDocumentCaster

### DIFF
--- a/src/DOMDocumentCaster.php
+++ b/src/DOMDocumentCaster.php
@@ -10,13 +10,13 @@ use Xttribute\Xttribute\Castables\CastTo;
 use Xttribute\Xttribute\Exceptions\IdentifyValueException;
 
 /**
- * @template T
+ * @template T of object
  */
 class DOMDocumentCaster
 {
     /**
      * @param DOMDocument $doc
-     * @param T $castTo
+     * @param class-string<T> $castTo
      * @return T
      * @throws ReflectionException
      * @throws IdentifyValueException


### PR DESCRIPTION
The second parameter of `DOMDocumentCaster::cast()` must be a string, whereas its annotation was loosely defined as `T`. However, the type of `T` is not explicitly defined, leading to issues with static code analyzers, e.g. PHPStan. To resolve these issues, `T` is now defined as subtype of `object` and the second parameter of `DOMDocumentCaster::cast()` is described as `class-string` of `T`.