### PR TITLE
Move class-level generic annotation to method

### DIFF
--- a/src/DOMDocumentCaster.php
+++ b/src/DOMDocumentCaster.php
@@ -9,12 +9,10 @@ use ReflectionException;
 use Xttribute\Xttribute\Castables\CastTo;
 use Xttribute\Xttribute\Exceptions\IdentifyValueException;
 
-/**
- * @template T of object
- */
 class DOMDocumentCaster
 {
     /**
+     * @template T of object
      * @param DOMDocument $doc
      * @param class-string<T> $castTo
      * @return T


### PR DESCRIPTION
Hey there, thanks for creating this package!

I've moved the class-level generic annotation to the `cast()` method. Class-level generic annotations only make sense when the class is meant to be extended, or the implementation of the generic depends on the constructor. Neither is the case here I believe.

Tested with PHPStan 1.9.3.

Could you please consider tagging a release after merging?