### PR TITLE
Incorrect readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,16 @@ Then we can run it through our ```DomDocumentCaster``` and get our hydrated obje
 ```php
 use Xttribute\Xttribute\DOMDocumentCaster;
 
-// $source to be populated, however you're receiving your XML
+// populate $source here with however you're receiving your XML
 
-$xml = new DOMDocument();
-$xml->loadXML($source);
+$doc = new DOMDocument();
+$doc->loadXML($source);
 
 $caster = new DOMDocumentCaster();
-$caster->cast($doc, Note::class)
+/** @var Note $note */
+$note = $caster->cast($doc, Note::class);
+
+// Work with $note hydrated DTO...
 ```
 
 Other ways of using this package can be found in our [examples](https://github.com/BennyC/xttribute/tree/main/examples).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Given the following XML
 
 We can translate this easily to the following class with some attributes! 
 ```php
-use Xttribute\Xttribute\Castable\Str;
+use Xttribute\Xttribute\Castables\Str;
 
 class Note 
 {

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ $doc = new DOMDocument();
 $doc->loadXML($source);
 
 $caster = new DOMDocumentCaster();
-/** @var Note $note */
 $note = $caster->cast($doc, Note::class);
 
 // Work with $note hydrated DTO...


### PR DESCRIPTION
Fixed a couple of stuff in `README.md`
- Missing semicolon 
- Incorrect variable used(incorrect workflow)
- Hydrated DTO not assigned
- Incorrect namespace used (castable instead of castable**s**)
- Added better comments

_(great library! I began using this in the workplace project. It was a breeze indeed even with particularly complex nested structures!)_