### PR TITLE
Fix `Boolean` attribute target

### DIFF
--- a/src/Castables/Boolean.php
+++ b/src/Castables/Boolean.php
@@ -9,7 +9,7 @@ use DOMDocument;
 use Xttribute\Xttribute\Exceptions\IdentifyValueException;
 use Xttribute\Xttribute\Exceptions\InvalidTypeException;
 
-#[Attribute(Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_PROPERTY)]
 class Boolean extends Str
 {
     /**


### PR DESCRIPTION
Currently seeing this error when using `#[Boolean(...)]` on a promoted constructor property:

```
Attribute "Xttribute\Xttribute\Castables\Boolean" cannot target property (allowed targets: parameter)
```

All castables, except `Boolean`, target properties. I guess this was an oversight.